### PR TITLE
We should use 60 seconds as the default timeout value for selenium

### DIFF
--- a/upetem.robot
+++ b/upetem.robot
@@ -33,6 +33,7 @@ ${auction_url}
 
 Вхід
   [Arguments]  ${username}
+  Set Selenium Timeout  60
   Wait Until Page Contains Element    xpath=//*[text()='Вхід']
   Click Element                      xpath=//*[text()='Вхід']
   Wait Until Page Contains Element   id=mForm:email


### PR DESCRIPTION
Set Selenium Timeout   X
Устанавливает дефолтное максимальное время ожидания в таких кейвордах как
Wait Until XXX и т.д.
Можно абсолютно безболезненно устанавливать 60 секунд
Это не означает что придётся всегда ждать 60 секунд
Мы просто даём запас времени на ожидание
10 секунд для нас мало

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests.broker.upetem/8)
<!-- Reviewable:end -->
